### PR TITLE
docs: fix simple typo, accomidate -> accommodate

### DIFF
--- a/sod_img_reader.h
+++ b/sod_img_reader.h
@@ -7656,7 +7656,7 @@ STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *c, void *user
 	  1.31  (2011-06-20)
 			  a few more leak fixes, bug in PNG handling (SpartanJ)
 	  1.30  (2011-06-11)
-			  added ability to load files via callbacks to accomidate custom input streams (Ben Wenger)
+			  added ability to load files via callbacks to accommodate custom input streams (Ben Wenger)
 			  removed deprecated format-specific test/load functions
 			  removed support for installable file formats (stbi_loader) -- would have been broken for IO callbacks anyway
 			  error cases in bmp and tga give messages and don't leak (Raymond Barbiero, grisha)


### PR DESCRIPTION
There is a small typo in sod_img_reader.h.

Should read `accommodate` rather than `accomidate`.

